### PR TITLE
Update paper.bib

### DIFF
--- a/paper.bib
+++ b/paper.bib
@@ -322,7 +322,7 @@ url = {https://diataxis.fr/}
     Year = {2016}
 }
 
- @misc{Caswell_Droettboom_Lee_Andrade_Hoffmann_Hunter_Klymak_Firing_Stansby_Varoquaux_etal_2021, 
+ @software{Caswell_Droettboom_Lee_Andrade_Hoffmann_Hunter_Klymak_Firing_Stansby_Varoquaux_etal_2021, 
         title={matplotlib/matplotlib: REL: v3.5.1}, 
         url={https://doi.org/10.5281/zenodo.5773480}, 
         DOI={10.5281/zenodo.5773480}, 
@@ -331,7 +331,7 @@ url = {https://diataxis.fr/}
         year={2021}, month=dec }
         
 
- @misc{JupyterBookCommunity_2021, 
+ @software{JupyterBookCommunity_2021, 
         title={Jupyter Book}, 
         url={https://doi.org/10.5281/zenodo.4539666}, 
         DOI={10.5281/zenodo.4539666}, 
@@ -339,7 +339,7 @@ url = {https://diataxis.fr/}
         author={{Executable Books Community}}, 
         year={2021}, month=feb }
 
- @misc{Gillies_van_der_Wel_Van_den_Bossche_Taves_Arnott_Ward_others_2022, 
+ @software{Gillies_van_der_Wel_Van_den_Bossche_Taves_Arnott_Ward_others_2022, 
         title={Shapely}, 
         url={https://doi.org/10.5281/zenodo.7428463}, 
         DOI={10.5281/zenodo.7428463}, 
@@ -357,7 +357,7 @@ url = {https://diataxis.fr/}
         author={Hoyer, Stephan and Hamman, Joe}, 
         year={2017}, month=apr, pages={10}, language={en} }
 
- @misc{Jordahl_Bossche_Fleischmann_McBride_Wasserman_Badaracco_Gerard_Snow_Tratner_Perry_etal_2021, 
+ @software{Jordahl_Bossche_Fleischmann_McBride_Wasserman_Badaracco_Gerard_Snow_Tratner_Perry_etal_2021, 
         title={geopandas/geopandas: v0.10.0}, 
         url={https://doi.org/10.5281/zenodo.5546558}, 
         DOI={10.5281/zenodo.5546558}, 
@@ -365,33 +365,46 @@ url = {https://diataxis.fr/}
         author={Jordahl, Kelsey and Bossche, Joris Van den and Fleischmann, Martin and McBride, James and Wasserman, Jacob and Badaracco, Adrian Garcia and Gerard, Jeffrey and Snow, Alan D. and Tratner, Jeff and Perry, Matthew and Farmer, Carson and Hjelle, Geir Arne and Cochran, Micah and Gillies, Sean and Culbertson, Lucas and Bartos, Matt and Ward, Brendan and Caria, Giacomo and Taves, Mike and Eubank, Nick and sangarshanan and Flavin, John and Richards, Matt and Rey, Sergio and maxalbert and Bilogur, Aleksey and Ren, Christopher and Arribas-Bel, Dani and Mesejo-León, Daniel and Wasser, Leah}, 
         year={2021}, month=oct }
 
- @misc{Miles_Kirkham_Durant_Bourbeau_Onalan_Hamman_Patel_shikharsg_Rocklin_dussin_etal_2020, 
+ @software{Miles_Kirkham_Durant_Bourbeau_Onalan_Hamman_Patel_shikharsg_Rocklin_dussin_etal_2020, 
         title={zarr-developers/zarr-python: v2.4.0}, 
         url={https://doi.org/10.5281/zenodo.3773450}, 
         DOI={10.5281/zenodo.3773450}, publisher={Zenodo}, 
         author={Miles, Alistair and Kirkham, John and Durant, Martin and Bourbeau, James and Onalan, Tarik and Hamman, Joe and Patel, Zain and shikharsg and Rocklin, Matthew and dussin, raphael and Schut, Vincent and Andrade, Elliott Sales de and Abernathey, Ryan and Noyes, Charles and sbalmer and bot, pyup io and Tran, Tommy and Saalfeld, Stephan and Swaney, Justin and Moore, Josh and Jevnik, Joe and Kelleher, Jerome and Funke, Jan and Sakkis, George and Barnes, Chris and Banihirwe, Anderson}, 
         year={2020}, month=apr }
- @misc{Snow_Brochart_Raspaud_Taves_Bell_RichardScottOZ_Chegini_Amici_Braun_Annex_etal_2022, 
+ @software{Snow_Brochart_Raspaud_Taves_Bell_RichardScottOZ_Chegini_Amici_Braun_Annex_etal_2022, 
         title={corteva/rioxarray: 0.12.1}, 
         url={https://doi.org/10.5281/zenodo.7080195}, 
         DOI={10.5281/zenodo.7080195}, 
         publisher={Zenodo}, 
         author={Snow, Alan D. and Brochart, David and Raspaud, Martin and Taves, Mike and Bell, Ray and RichardScottOZ and Chegini, Taher and Amici, Alessandro and Braun, Rémi and Annex, Andrew and Brandt, Carlos H. and Hoese, David and Bunt, Fred and GBallesteros and Scheick, Jessica and Hamman, Joe and jonasViehweger and Zehner, Markus and Cordeiro, Mauricio and Henderson, Scott and Miller, Seth and Badger, The Gitter and Augspurger, Tom and apiwat-chantawibul and pmallas}, 
         year={2022}, month=sep }
- @misc{Source_McFarland_Emanuele_Morris_Augspurger_2022, 
+ @software{Source_McFarland_Emanuele_Morris_Augspurger_2022, 
         title={microsoft/PlanetaryComputer: October 2022}, 
         url={https://doi.org/10.5281/zenodo.7261897},
         DOI={10.5281/zenodo.7261897}, 
         publisher={Zenodo}, 
         author={Microsoft Open Source and McFarland, Matt and Emanuele, Rob and Morris, Dan and Augspurger, Tom}, 
         year={2022}, month=oct }
- @misc{Pandasteam_2024, 
-        title={pandas-dev/pandas: Pandas}, 
-        url={https://doi.org/10.5281/zenodo.10537285}, 
-        DOI={10.5281/zenodo.10537285},
-        publisher={Zenodo}, 
-        author={The pandas development team}, 
-        year={2024}, month=jan }
+ 
+  @software{Pandasteam_2024,
+        title = {Pandas-Dev/Pandas: {{Pandas}}},
+        author = {{The pandas development team}},
+        year = {2024},
+        month = jan,
+        publisher = {Zenodo},
+        version = {latest},
+        doi = {10.5281/zenodo.10537285}
+      }
+@InProceedings{ mckinney-proc-scipy-2010,
+        author    = { {W}es {M}c{K}inney },
+        title     = { {D}ata {S}tructures for {S}tatistical {C}omputing in {P}ython },
+        booktitle = { {P}roceedings of the 9th {P}ython in {S}cience {C}onference },
+        pages     = { 56 - 61 },
+        year      = { 2010 },
+        editor    = { {S}t\'efan van der {W}alt and {J}arrod {M}illman },
+        doi       = { 10.25080/Majora-92bf1922-00a }
+      }
+
 
 @InProceedings{DaskLibrary,
   author    = { {M}atthew {R}ocklin },


### PR DESCRIPTION
update pandas refs

This PR fixes the formatting of the author field on the pandas software reference. it also adds a reference to hte pandas paper (following [guidelines](https://pandas.pydata.org/about/citing.html)) and updates the bibtex types from misc to software for several entries.